### PR TITLE
fix issue with grant dump output difference in mysql 5.7

### DIFF
--- a/src/Task/Mysql/DumpGrants.php
+++ b/src/Task/Mysql/DumpGrants.php
@@ -137,7 +137,6 @@ class DumpGrants extends BaseTask implements BuilderAwareInterface
         }
 
         return $line;
-
     }
 
     protected function replaceDatabase(string $line) : string

--- a/src/Task/Mysql/DumpGrants.php
+++ b/src/Task/Mysql/DumpGrants.php
@@ -129,12 +129,15 @@ class DumpGrants extends BaseTask implements BuilderAwareInterface
 
     protected function replacePassword(string $line) : string
     {
-        if (!empty($this->destinationPassword)) {
-            return preg_replace('/PASSWORD <secret>/', "'" . $this->destinationPassword . "'", $line);
+        // Strip IDENTIFIED BY PASSWORD <secret> section from MySQL 5.6
+        $line = preg_replace('/ IDENTIFIED BY PASSWORD <secret>/', '', $line);
+
+        if (!empty($this->destinationPassword) && preg_match('/^GRANT USAGE ON/', $line)) {
+            $line .= sprintf(" IDENTIFIED BY '%s'", $this->destinationPassword);
         }
 
-        // If no password specified, remove the IDENTIFIED BY section completely
-        return preg_replace('/ IDENTIFIED BY PASSWORD <secret>/', '', $line);
+        return $line;
+
     }
 
     protected function replaceDatabase(string $line) : string


### PR DESCRIPTION
MySQL 5.7 doesn't include the `IDENTIFIED BY PASSWORD <secret>` section when dumping the grants. This change will remove that text if there, and append the correct password to the end of any `GRANT USAGE ON` statements.